### PR TITLE
Check for empty output at export

### DIFF
--- a/bin/codimd
+++ b/bin/codimd
@@ -32,7 +32,9 @@ function import_note() {
 
 function export_note() {
     if [[ -z "$3"  ]]; then
-        echo "ERROR: output is empty"
+        echo "ERROR: You must specify a file path to save the output to."
+        echo ""
+        echo "Usage: codimd export [--pdf|--md|--html|--slides] <note_id> <output_file>"
         exit 1
      else
         if [[ $1 == "--pdf" ]]; then

--- a/bin/codimd
+++ b/bin/codimd
@@ -31,18 +31,23 @@ function import_note() {
 }
 
 function export_note() {
-    if [[ $1 == "--pdf" ]]; then
-        wget -O "$3" "$CODIMD_SERVER/$2/pdf"
-    elif [[ $1 == "--md" ]]; then
-        wget -O "$3" "$CODIMD_SERVER/$2/download"
-    elif [[ $1 == "--html" ]]; then
-        publish_url=$(publish_note "$2")
-        wget --recursive --convert-links -O "$3" "$CODIMD_SERVER$publish_url"
-    elif [[ $1 == "--slides" ]]; then
-        wget --recursive --convert-links -O "$3" "$CODIMD_SERVER/$2/slide"
-    else
-        echo "Usage: codimd export [--pdf|--md|--html|--slides] <note_id> <output_file>"
-    fi
+    if [[ -z "$3"  ]]; then
+        echo "ERROR: output is empty"
+        exit 1
+     else
+        if [[ $1 == "--pdf" ]]; then
+            wget -O "$3" "$CODIMD_SERVER/$2/pdf"
+        elif [[ $1 == "--md" ]]; then
+            wget -O "$3" "$CODIMD_SERVER/$2/download"
+        elif [[ $1 == "--html" ]]; then
+            publish_url=$(publish_note "$2")
+            wget --recursive --convert-links -O "$3" "$CODIMD_SERVER$publish_url"
+        elif [[ $1 == "--slides" ]]; then
+            wget --recursive --convert-links -O "$3" "$CODIMD_SERVER/$2/slide"
+        else
+            echo "Usage: codimd export [--pdf|--md|--html|--slides] <note_id> <output_file>"
+        fi
+      fi
 }
 
 if [[ "$1" == "import" ]]; then


### PR DESCRIPTION
If you don't state a output file else you'll get a `No such file or directory` error. This gives a nice error.

There are probably better ways to do it but this works. I first thought the initial error was that the pad wasn't available on the padserver and didn't understand that this meant the local filesystem. Another way would be to use the pad-name with ".md" as extension as default filename if none is given.