### PR TITLE
Url encode email and password with curl

### DIFF
--- a/bin/codimd
+++ b/bin/codimd
@@ -78,7 +78,7 @@ function authenticate_email() {
 
     curl -c $CODIMD_COOKIES_FILE \
         -XPOST \
-        -d "email=$1&password=$2" \
+        --data-urlencode "email=$1" --data-urlencode "password=$2" \
         $CODIMD_SERVER/login &>/dev/null
 }
 


### PR DESCRIPTION
If the email or password contains some special characters, like "&", the login will fail. This PR fixes the issue